### PR TITLE
change cdn provider

### DIFF
--- a/math_with_slack.bat
+++ b/math_with_slack.bat
@@ -142,7 +142,7 @@ FOR /F "delims=" %%L IN (%SLACK_INDEX%.mwsbak) DO (
 			ECHO.        \`;
 			ECHO.      var mathjax_script = document.createElement("script"^);
 			ECHO.      mathjax_script.type = "text/javascript";
-			ECHO.      mathjax_script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js";
+			ECHO.      mathjax_script.src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js";
 			ECHO.      document.getElementsByTagName("head"^)[0].appendChild(mathjax_config^);
 			ECHO.      document.getElementsByTagName("head"^)[0].appendChild(mathjax_script^);
 			ECHO.

--- a/math_with_slack.sh
+++ b/math_with_slack.sh
@@ -176,7 +176,7 @@ a
         \\\`;
       var mathjax_script = document.createElement("script");
       mathjax_script.type = "text/javascript";
-      mathjax_script.src = "https://cdn.mathjax.org/mathjax/latest/MathJax.js";
+      mathjax_script.src = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js";
       document.getElementsByTagName("head")[0].appendChild(mathjax_config);
       document.getElementsByTagName("head")[0].appendChild(mathjax_script);
 


### PR DESCRIPTION
[MathJax CDN shutting down on April 30, 2017](https://www.mathjax.org/cdn-shutting-down/)