### PR TITLE
Fixed problem with editing messages

### DIFF
--- a/math_with_slack.bat
+++ b/math_with_slack.bat
@@ -82,7 +82,7 @@ IF EXIST "%SLACK_INDEX%.mwsbak" (
 FOR /F "skip=1 delims=" %%L IN ('CertUtil -hashfile %SLACK_INDEX%') DO SET "INDEX_HASH=%%L" & GOTO breakhashloop
 :breakhashloop
 
-IF "%FORCE%" == "" IF NOT "%INDEX_HASH%" == "d4 05 45 4d 96 c6 ac df 4e fa 1d 7c 8a 3a 91 eb 08 69 c3 c8" (
+IF "%FORCE%" == "" IF NOT "%INDEX_HASH%" == "f07fabb32b109500fb264083b8685a85197df522" (
 	ECHO Unrecognized index file: %SLACK_INDEX%
 	ECHO Call with '-f' flag to suppress this check.
 	PAUSE & EXIT /B 1
@@ -91,7 +91,7 @@ IF "%FORCE%" == "" IF NOT "%INDEX_HASH%" == "d4 05 45 4d 96 c6 ac df 4e fa 1d 7c
 
 :: Ensure "index.js" contains "startup();"
 
-FINDSTR /R /C:"^    startup();$" "%SLACK_INDEX%" >NUL
+FINDSTR /R /C:"^    startup();" "%SLACK_INDEX%" >NUL
 IF %ERRORLEVEL% NEQ 0 (
 	ECHO Cannot find 'startup(^);' in index file: %SLACK_INDEX%
 	PAUSE & EXIT /B 1

--- a/math_with_slack.bat
+++ b/math_with_slack.bat
@@ -131,6 +131,7 @@ FOR /F "delims=" %%L IN (%SLACK_INDEX%.mwsbak) DO (
 			ECHO.          jax: ["input/TeX", "output/HTML-CSS"],
 			ECHO.          tex2jax: {
 			ECHO.            skipTags: ["script","noscript","style","textarea","pre","code"],
+			ECHO.            ignoreClass: "ql-editor",
 			ECHO.            inlineMath: [ ['\$','\$'] ],
 			ECHO.            displayMath: [ ['\$\$','\$\$'] ],
 			ECHO.            processEscapes: true

--- a/math_with_slack.sh
+++ b/math_with_slack.sh
@@ -165,6 +165,7 @@ a
           jax: ["input/TeX", "output/HTML-CSS"],
           tex2jax: {
             skipTags: ["script","noscript","style","textarea","pre","code"],
+            ignoreClass: "ql-editor",
             inlineMath: [ ['\$','\$'] ],
             displayMath: [ ['\$\$','\$\$'] ],
             processEscapes: true


### PR DESCRIPTION
I've only tested the Windows version. And I don't claim to completely understand why this works. I added a line to prevent MathJax from trying to render edit fields thinking that other fixes would be needed too, but this seems to fix everything.

In particular, (1) LaTeX does not disappear after any length of time while a new message is being created, (2) when you edit an existing message, the LaTeX code is restored within $ delimiters and no duplication of LaTeX happens.