### PR TITLE
Pick installation dir by date instead of alphabetically

### DIFF
--- a/math_with_slack.bat
+++ b/math_with_slack.bat
@@ -41,7 +41,7 @@ GOTO parse
 :: Try to find slack if not provided by user
 
 IF "%SLACK_DIR%" == "" (
-	FOR /F %%t IN ('DIR /B /ON %UserProfile%\AppData\Local\slack\app-?.*.*') DO (
+	FOR /F %%t IN ('DIR /B /OD %UserProfile%\AppData\Local\slack\app-?.*.*') DO (
 		SET SLACK_DIR=%UserProfile%\AppData\Local\slack\%%t\resources\app.asar.unpacked\src\static
 	)
 )


### PR DESCRIPTION
Suggested change for Issue #17. Sorts the candidate installation directories by date instead of by name to pick the most recent one for the install.