### PR TITLE
Check if file exists, to deal with missing -lite file

### DIFF
--- a/math_with_slack.sh
+++ b/math_with_slack.sh
@@ -94,6 +94,14 @@ fi
 ## Restore previous injections
 
 restore_file() {
+	# Check if file exists
+	# If it doesn't just silently return, to cope with nonexistent
+	# files in different slack-desktop versions.
+	if [ ! -e $1 ]; then
+		echo "File $1 doesn't exist."
+		return 0
+	fi
+
 	# Test so file been injected. If not, assume it's more recent than backup
 	if grep -q "math-with-slack" $1; then
 		if [ -e "$1.mwsbak" ]; then
@@ -162,6 +170,14 @@ EOF
 ## Inject code loader
 
 inject_loader() {
+	# Check if file exists
+	# If it doesn't just silently return, to cope with nonexistent
+	# files in different slack-desktop versions.
+	if [ ! -e $1 ]; then
+		echo "File $1 doesn't exist."
+		return 0
+	fi
+
 	# Check so not already injected
 	if grep -q "math-with-slack" $1; then
 		error "File already injected: $1"

--- a/math_with_slack.sh
+++ b/math_with_slack.sh
@@ -98,7 +98,6 @@ restore_file() {
 	# If it doesn't just silently return, to cope with nonexistent
 	# files in different slack-desktop versions.
 	if [ ! -e $1 ]; then
-		echo "File $1 doesn't exist."
 		return 0
 	fi
 
@@ -174,7 +173,6 @@ inject_loader() {
 	# If it doesn't just silently return, to cope with nonexistent
 	# files in different slack-desktop versions.
 	if [ ! -e $1 ]; then
-		echo "File $1 doesn't exist."
 		return 0
 	fi
 


### PR DESCRIPTION
The newest version of slack-desktop for Linux (3.0.0) remove the ssb-interop-lite.js file.

Right now the script terminates, because it doesn't check if the file exists.

The small fix: check if file exists in both restore_ and inject_ functions.  If file doesn't exist, then just silently return.  This way the script works with both older slack-desktop versions and the newest one.