### PR TITLE
Fix Windows install detection when username has spaces

### DIFF
--- a/math-with-slack.bat
+++ b/math-with-slack.bat
@@ -41,7 +41,7 @@ GOTO parse
 :: Try to find slack if not provided by user
 
 IF "%SLACK_DIR%" == "" (
-	FOR /F %%t IN ('DIR /B /OD %UserProfile%\AppData\Local\slack\app-?.*.*') DO (
+	FOR /F %%t IN ('DIR /B /OD "%UserProfile%\AppData\Local\slack\app-?.*.*"') DO (
 		SET SLACK_DIR=%UserProfile%\AppData\Local\slack\%%t\resources\app.asar.unpacked\src\static
 	)
 )


### PR DESCRIPTION
Noticed this while putting together [a derivative](https://github.com/IvyBits/old-slack-emojis) to fix Slack emojis; if the path isn't quoted and username has spaces, you get errors like:

```
> math-with-slack.bat
The system cannot find the path specified.
Cannot find Slack installation.
Press any key to continue . . .
```