### PR TITLE
Fix python script to work on Windows

### DIFF
--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -68,7 +68,11 @@ elif sys.platform == 'linux':
             app_path = test_app_file
             break
 elif sys.platform == 'win32':
-   exprint('Not implemented')
+    import glob
+    app_path = glob.glob(
+        os.path.join(os.environ["UserProfile"],
+                     "AppData\\Local\\slack\\app-?.*.*/resources/app.asar"))[-1]
+    
 
 
 # Check so app.asar file exists


### PR DESCRIPTION
I modified the python script to work on Windows.  I am using python 3.7.3 distribution from anaconda. 

Aside from the changes in the python code, I had to quit slack prior to running the script in order to make it work.  Then when restarting slack, I did see the math show up.

You will need to update README.md to tell people how to run the python script, and also where to get python if they don't have it.
