### PR TITLE
Fix #49 and #51, might have performance implications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,22 @@ The downside is that equations are not rendered for team members without the Mat
 
 ## How do I install it?
 
-Download and run the script. Restart the Slack client. You're done!
+Get and run the script. Restart the Slack client. You're done!
 
+### Getting the script
 
 ### Mac and Linux
 
 Run the following in a terminal:
 
 ```shell
-curl -OL https://github.com/fsavje/math-with-slack/releases/download/v0.2.5/math-with-slack.sh
-sudo bash math-with-slack.sh
+curl -OL https://raw.githubusercontent.com/psg-mit/math-with-slack/v3/math-with-slack.py
+sudo python math-with-slack.py
 ```
 
-
 ### Windows
+
+!!! Current support for windows is unknown
 
 [Download the script](https://github.com/fsavje/math-with-slack/releases/download/v0.2.5/math-with-slack.bat) and double-click to run. Alternatively, run it in the command prompt with:
 

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -28,7 +28,7 @@ import os
 import shutil
 import struct
 import sys
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 try:
     # Python 3
@@ -240,13 +240,13 @@ def read_package_json():
 
 def read_slack_version():
     package_json = read_package_json()
-    return StrictVersion(package_json['version'])
+    return LooseVersion(package_json['version'])
 
 slack_version = read_slack_version()
 
-if slack_version == StrictVersion('4.3.3'):
+if LooseVersion('4.3') <= slack_version < LooseVersion('4.4'):
     injected_file_name = 'main-preload-entry-point.bundle.js'
-elif slack_version == StrictVersion('4.4.1'):
+elif LooseVersion('4.4') <= slack_version:
     injected_file_name = 'preload.bundle.js'
 else:
     exprint("Unsupported Slack Version {}.".format(slack_version))

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -205,19 +205,10 @@ document.addEventListener('DOMContentLoaded', function() {
   var mathjax_observer = document.createElement('script');
   mathjax_observer.type = 'text/x-mathjax-config';
   mathjax_observer.text = `
-    var options = { attributes: false, childList: true, characterData: true, subtree: false };
-    var observer = new MutationObserver(
-        function (mutations, observer) {
-            mutations.forEach(function(mutation) {
-                MathJax.Hub.Queue(['Typeset', MathJax.Hub, mutation.target]);
-            });
-        }
-    );
     var entry_observer = new IntersectionObserver(function (entries, observer) {
         entries.forEach(function(entry) {
             if(entry.intersectionRatio > 0) {
                 MathJax.Hub.Queue(['Typeset', MathJax.Hub, entry.target]);
-                observer.observe(msg, options);
             }
         });
         }, 

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -181,6 +181,7 @@ if args.uninstall:
 inject_code = ('\n\n// math-with-slack ' + mws_version + '''
 // https://github.com/fsavje/math-with-slack
 document.addEventListener('DOMContentLoaded', function() {
+  localStorage.lastBootSonicValue = "once"; // tricks Slack to not override setting!
   var mathjax_config = document.createElement('script');
   mathjax_config.type = 'text/x-mathjax-config';
   mathjax_config.text = `

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -52,7 +52,7 @@ parser = argparse.ArgumentParser(prog='math-with-slack', description='Inject Sla
 parser.add_argument('-a', '--app-file', help='Path to Slack\'s \'app.asar\' file.')
 parser.add_argument('--mathjax-url', 
                     help='Url to download mathjax release.', 
-                    default='https://registry.npmjs.org/mathjax/-/mathjax-3.0.0.tgz')
+                    default='https://registry.npmjs.org/mathjax/-/mathjax-3.0.1.tgz')
 parser.add_argument('-u', '--uninstall', action='store_true', help='Removes injected MathJax code.')
 parser.add_argument('--version', action='version', version='%(prog)s ' + mws_version)
 args = parser.parse_args()
@@ -158,6 +158,12 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   window.MathJax = {
+    options: {
+        skipHtmlTags: [
+            'script', 'noscript', 'style', 'textarea', 'pre',
+            'code', 'annotation', 'annotation-xml'
+        ],
+    },
     loader: {
         paths: {mathjax: 'mathjax/es5'},
         source: {},
@@ -174,8 +180,6 @@ document.addEventListener('DOMContentLoaded', function() {
       packages: {'[+]': ['ams', 'color', 'noerrors', 'noundefined', 'boldsymbol']},
       inlineMath: [['$', '$']],
       displayMath: [['$$', '$$']],
-      // the following doesn't seem to work with MathJax 3
-      // skipTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
     },
     startup: {
       ready: () => {

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -152,13 +152,24 @@ document.addEventListener('DOMContentLoaded', function() {
   function typeset(element) {
     const MathJax = window.MathJax;
     MathJax.startup.promise = MathJax.startup.promise
-      .then(() => {return MathJax.typesetPromise(element);})
+      .then(() => {console.log(element); return MathJax.typesetPromise(element);})
       .catch((err) => console.log('Typeset failed: ' + err.message));
     return MathJax.startup.promise;
   }
 
   window.MathJax = {
-    loader: {load: ['[tex]/ams', '[tex]/color', '[tex]/noerrors', '[tex]/noundefined', '[tex]/boldsymbol']},
+    loader: {
+        paths: {mathjax: 'mathjax/es5'},
+        source: {},
+        require: require,
+        load: [
+            'input/tex-full',
+            'output/svg',
+            '[tex]/noerrors', 
+            '[tex]/noundefined', 
+            '[tex]/boldsymbol'
+        ]
+    },
     tex: {
       packages: {'[+]': ['ams', 'color', 'noerrors', 'noundefined', 'boldsymbol']},
       inlineMath: [['$', '$']],
@@ -173,8 +184,10 @@ document.addEventListener('DOMContentLoaded', function() {
         var entry_observer = new IntersectionObserver(
           (entries, observer) => {
             var appearedEntries = entries.filter((entry) => entry.intersectionRatio > 0);
-            console.log(appearedEntries);
-            typeset(appearedEntries.map((entry) => entry.target));
+            if(appearedEntries.length) {
+                console.log(appearedEntries);
+                typeset(appearedEntries.map((entry) => entry.target));
+            }
           }, 
           { root: document.body }
         );
@@ -197,7 +210,7 @@ document.addEventListener('DOMContentLoaded', function() {
   };
 
   // Import mathjax
-  require("mathjax/es5/tex-svg-full");
+  require("mathjax/es5/startup.js");
 
 });
 ''').encode('utf-8')

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -28,7 +28,7 @@ import os
 import shutil
 import struct
 import sys
-import packaging.version
+from distutils.version import StrictVersion
 
 try:
     # Python 3
@@ -240,13 +240,13 @@ def read_package_json():
 
 def read_slack_version():
     package_json = read_package_json()
-    return packaging.version.parse(package_json['version'])
+    return StrictVersion(package_json['version'])
 
 slack_version = read_slack_version()
 
-if slack_version == packaging.version.parse('4.3.3'):
+if slack_version == StrictVersion('4.3.3'):
     injected_file_name = 'main-preload-entry-point.bundle.js'
-elif slack_version == packaging.version.parse('4.4.1'):
+elif slack_version == StrictVersion('4.4.1'):
     injected_file_name = 'preload.bundle.js'
 else:
     exprint("Unsupported Slack Version {}.".format(slack_version))

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -262,6 +262,7 @@ slack_version = read_slack_version()
 
 if LooseVersion('4.3') <= slack_version < LooseVersion('4.4'):
     injected_file_name = 'main-preload-entry-point.bundle.js'
+    include_mathjax_inline = False
 elif LooseVersion('4.4') <= slack_version < LooseVersion('4.6'):
     injected_file_name = 'preload.bundle.js'
     include_mathjax_inline = False

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -70,7 +70,7 @@ if args.app_file is not None:
     app_path = args.app_file
 elif sys.platform == 'darwin':
     app_path = '/Applications/Slack.app/Contents/Resources/app.asar'
-elif sys.platform == 'linux':
+elif sys.platform.startswith('linux'):
     for test_app_file in [
         '/usr/lib/slack/resources/app.asar',
         '/usr/local/lib/slack/resources/app.asar',
@@ -155,7 +155,9 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   window.MathJax = {
+    loader: {load: ['[tex]/ams', '[tex]/color', '[tex]/noerrors', '[tex]/noundefined', '[tex]/boldsymbol']},
     tex: {
+      packages: {'[+]': ['ams', 'color', 'noerrors', 'noundefined', 'boldsymbol']},
       inlineMath: [['$', '$']],
       displayMath: [['$$', '$$']],
       // the following doesn't seem to work with MathJax 3

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -318,6 +318,10 @@ def dir_to_json_header(root_dir, initial_offset):
             offset += size
     return result, file_paths
 
+
+ori_injected_file_size = json_header['files']['dist']['files'][injected_file_name]['size']
+ori_injected_file_offset = int(json_header['files']['dist']['files'][injected_file_name]['offset'])
+
 # Download MathJax, currently assumes downloaded file is a tar called package.tar
 
 mathjax_tar_name, headers = urllib_request.urlretrieve(args.mathjax_url)
@@ -337,11 +341,6 @@ else:
     mathjax_src = "require('mathjax/es5/startup.js');"
 
 inject_code = inject_code.replace(b"$MATH_JAX_STUB$", mathjax_src)
-
-
-ori_injected_file_size = json_header['files']['dist']['files'][injected_file_name]['size']
-ori_injected_file_offset = int(json_header['files']['dist']['files'][injected_file_name]['offset'])
-
 
 # Modify JSON data
 

--- a/math-with-slack.py
+++ b/math-with-slack.py
@@ -15,7 +15,7 @@
 #
 ################################################################################
 
-# Python 2.7
+# Python 2.7 and 3
 
 from __future__ import print_function
 
@@ -28,7 +28,14 @@ import os
 import shutil
 import struct
 import sys
-import urllib.request
+
+try:
+    # Python 3
+    import urllib.request as urllib_request
+except:
+    # Python 2
+    import urllib as urllib_request
+
 import tarfile
 import tempfile
 
@@ -275,12 +282,12 @@ def dir_to_json_header(root_dir, initial_offset):
 
 # Download MathJax, currently assumes downloaded file is a tar called package.tar
 
-mathjax_tar_name, headers = urllib.request.urlretrieve(args.mathjax_url)
-mathjax_tmp_dir = tempfile.TemporaryDirectory()
+mathjax_tar_name, headers = urllib_request.urlretrieve(args.mathjax_url)
+mathjax_tmp_dir = tempfile.mkdtemp()
 mathjax_tar = tarfile.open(mathjax_tar_name)
-mathjax_tar.extractall(path=mathjax_tmp_dir.name)
+mathjax_tar.extractall(path=mathjax_tmp_dir)
 mathjax_tar.close()
-mathjax_dir = os.path.join(mathjax_tmp_dir.name, "package")
+mathjax_dir = os.path.join(mathjax_tmp_dir, "package")
 mathjax_json_header, append_file_paths = dir_to_json_header(mathjax_dir, ori_data_size + ori_injected_file_size + len(inject_code))
 json_header["files"]["node_modules"]["files"]["mathjax"] = mathjax_json_header["files"]["."]
 
@@ -316,7 +323,7 @@ with open(app_path + '.mwsbak', mode='rb') as ori_app_fp, \
 
 # We are done
 
-mathjax_tmp_dir.cleanup()
+shutil.rmtree(mathjax_tmp_dir)
 print('Install successful. Please restart Slack.')
 sys.exit(0)
 


### PR DESCRIPTION
An attempt to fix #49 and #51  

The problem (I think) was that the MutationObserver is somehow interfering with the keyboard space key event. Since the MutationObserver was applied on `$(#message_container)`s, in Threads view, this also included the input text field attached to each thread. 

In this pull request, I resorted to using DOMNodeInserted event, which doesn't seem to cause trouble with keyboard (though according to internet this should be deprecated for performance reason). As a compensation (I hope), in the event handler, I only attached IntersectionObserver which watches for DOM entry, and then mathjax the relevant pieces of text (instead of the entire message container as before).   


Edit:
Just realized that https://github.com/thisiscam/math-with-slack/blob/v3/math-with-slack.py#L184 also hacks away the problem of Slack rewriting the local settings file. 
Hacky but one-liner is always worth it 💯  